### PR TITLE
remove superfluous HasInfo constraints from the Serializable instances for SignKeyKES and VerKeyKES

### DIFF
--- a/kes-agent/src/Cardano/KESAgent/Processes/Agent/Context.hs
+++ b/kes-agent/src/Cardano/KESAgent/Processes/Agent/Context.hs
@@ -5,11 +5,6 @@
 module Cardano.KESAgent.Processes.Agent.Context
 where
 
-import Cardano.Crypto.KES.Class (KESAlgorithm (..))
-import Cardano.KESAgent.Serialization.DirectCodec
-import Data.SerDoc.Class (HasInfo (..))
-
-import Cardano.KESAgent.KES.Crypto (Crypto (..))
 import Cardano.KESAgent.Processes.Agent.Monad
 
 -- | For convenience: the typeclasses that are required for typical agent
@@ -17,6 +12,4 @@ import Cardano.KESAgent.Processes.Agent.Monad
 type AgentContext m c =
   ( MonadAgent m
   , AgentCrypto c
-  , HasInfo (DirectCodec m) (VerKeyKES (KES c))
-  , HasInfo (DirectCodec m) (SignKeyKES (KES c))
   )

--- a/kes-agent/src/Cardano/KESAgent/Processes/ControlClient.hs
+++ b/kes-agent/src/Cardano/KESAgent/Processes/ControlClient.hs
@@ -72,10 +72,7 @@ import Data.Char (toLower)
 import Data.Coerce
 import Data.Functor.Contravariant ((>$<))
 import Data.Kind
-import Data.SerDoc.Class (
-  HasInfo (..),
-  Serializable (..),
- )
+import Data.SerDoc.Class (Serializable (..))
 import qualified Data.Text as Text
 import Data.Typeable
 import Network.TypedProtocol.Driver (runPeerWithDriver)
@@ -154,7 +151,6 @@ type ControlClientCrypto c =
 type ControlClientContext m c =
   ( MonadControlClient m
   , ControlClientCrypto c
-  , HasInfo (DirectCodec m) (VerKeyKES (KES c))
   , Serializable (DirectCodec m) (VerKeyKES (KES c))
   , DirectSerialise (SignKeyKES (KES c))
   , DirectDeserialise (SignKeyKES (KES c))
@@ -235,7 +231,6 @@ instance
   , Crypto c
   , Typeable c
   , NamedCrypto c
-  , HasInfo (DirectCodec m) (VerKeyKES (KES c))
   , DirectSerialise (SignKeyKES (KES c))
   , DirectDeserialise (SignKeyKES (KES c))
   ) =>

--- a/kes-agent/src/Cardano/KESAgent/Processes/ServiceClient.hs
+++ b/kes-agent/src/Cardano/KESAgent/Processes/ServiceClient.hs
@@ -36,13 +36,12 @@ import Cardano.KESAgent.Protocols.Types
 import Cardano.KESAgent.Protocols.VersionHandshake.Driver
 import Cardano.KESAgent.Protocols.VersionHandshake.Peers
 import Cardano.KESAgent.Protocols.VersionedProtocol
-import Cardano.KESAgent.Serialization.DirectCodec
 import Cardano.KESAgent.Util.PlatformPoison (poisonWindows)
 import Cardano.KESAgent.Util.Pretty (Pretty (..))
 import Cardano.KESAgent.Util.RetrySocket (retrySocket)
 
 import Cardano.Crypto.DirectSerialise
-import Cardano.Crypto.KES.Class (SignKeyKES, VerKeyKES)
+import Cardano.Crypto.KES.Class (SignKeyKES)
 
 import Ouroboros.Network.RawBearer
 import Ouroboros.Network.Snocket (Snocket (..))
@@ -65,7 +64,6 @@ import Control.Monad.Class.MonadTimer (MonadDelay, threadDelay)
 import Control.Tracer (Tracer, traceWith)
 import Data.Char (toLower)
 import Data.Functor.Contravariant ((>$<))
-import Data.SerDoc.Class (HasInfo (..))
 import Data.Typeable
 import Data.Word (Word64)
 import Network.TypedProtocol.Driver (runPeerWithDriver)
@@ -164,8 +162,6 @@ type ServiceClientCrypto c =
 type ServiceClientContext m c =
   ( MonadServiceClient m
   , ServiceClientCrypto c
-  , HasInfo (DirectCodec m) (VerKeyKES (KES c))
-  , HasInfo (DirectCodec m) (SignKeyKES (KES c))
   )
 
 -- | Crypto types for which service client drivers are available.

--- a/kes-agent/src/Cardano/KESAgent/Protocols/Control/V0/Driver.hs
+++ b/kes-agent/src/Cardano/KESAgent/Protocols/Control/V0/Driver.hs
@@ -131,8 +131,6 @@ controlDriver ::
   Typeable c =>
   VersionedProtocol (ControlProtocol m c) =>
   KESAlgorithm (KES c) =>
-  HasInfo (DirectCodec m) (VerKeyKES (KES c)) =>
-  HasInfo (DirectCodec m) (AgentInfo c) =>
   Serializable (DirectCodec m) (AgentInfo c) =>
   DirectDeserialise (SignKeyKES (KES c)) =>
   DirectSerialise (SignKeyKES (KES c)) =>

--- a/kes-agent/src/Cardano/KESAgent/Protocols/Control/V1/Driver.hs
+++ b/kes-agent/src/Cardano/KESAgent/Protocols/Control/V1/Driver.hs
@@ -122,8 +122,6 @@ $(deriveSerDoc ''DirectCodec [] ''AgentInfo)
 controlDriver ::
   forall (m :: Type -> Type) f t p pr.
   VersionedProtocol (ControlProtocol m) =>
-  HasInfo (DirectCodec m) (VerKeyKES (KES StandardCrypto)) =>
-  HasInfo (DirectCodec m) AgentInfo =>
   Serializable (DirectCodec m) AgentInfo =>
   MonadThrow m =>
   MonadSTM m =>

--- a/kes-agent/src/Cardano/KESAgent/Protocols/Control/V2/Driver.hs
+++ b/kes-agent/src/Cardano/KESAgent/Protocols/Control/V2/Driver.hs
@@ -123,8 +123,6 @@ $(deriveSerDoc ''DirectCodec [] ''AgentInfo)
 controlDriver ::
   forall (m :: Type -> Type) f t p pr.
   VersionedProtocol (ControlProtocol m) =>
-  HasInfo (DirectCodec m) (VerKeyKES (KES StandardCrypto)) =>
-  HasInfo (DirectCodec m) AgentInfo =>
   Serializable (DirectCodec m) AgentInfo =>
   MonadThrow m =>
   MonadSTM m =>

--- a/kes-agent/src/Cardano/KESAgent/Protocols/Control/V3/Driver.hs
+++ b/kes-agent/src/Cardano/KESAgent/Protocols/Control/V3/Driver.hs
@@ -123,8 +123,6 @@ $(deriveSerDoc ''DirectCodec [] ''AgentInfo)
 controlDriver ::
   forall (m :: Type -> Type) f t p pr.
   VersionedProtocol (ControlProtocol m) =>
-  HasInfo (DirectCodec m) (VerKeyKES (KES StandardCrypto)) =>
-  HasInfo (DirectCodec m) AgentInfo =>
   Serializable (DirectCodec m) AgentInfo =>
   MonadThrow m =>
   MonadSTM m =>

--- a/kes-agent/src/Cardano/KESAgent/Protocols/Service/V0/Driver.hs
+++ b/kes-agent/src/Cardano/KESAgent/Protocols/Service/V0/Driver.hs
@@ -57,8 +57,6 @@ serviceDriver ::
   Typeable c =>
   VersionedProtocol (ServiceProtocol m c) =>
   KESAlgorithm (KES c) =>
-  HasInfo (DirectCodec m) (SignKeyKES (KES c)) =>
-  HasInfo (DirectCodec m) (VerKeyKES (KES c)) =>
   DirectDeserialise (SignKeyKES (KES c)) =>
   DirectSerialise (SignKeyKES (KES c)) =>
   MonadThrow m =>

--- a/kes-agent/src/Cardano/KESAgent/Protocols/Service/V1/Driver.hs
+++ b/kes-agent/src/Cardano/KESAgent/Protocols/Service/V1/Driver.hs
@@ -53,8 +53,6 @@ import Network.TypedProtocol.Driver
 serviceDriver ::
   forall m f t p pr.
   VersionedProtocol (ServiceProtocol m) =>
-  HasInfo (DirectCodec m) (SignKeyKES (KES StandardCrypto)) =>
-  HasInfo (DirectCodec m) (VerKeyKES (KES StandardCrypto)) =>
   DirectDeserialise (SignKeyKES (KES StandardCrypto)) =>
   DirectSerialise (SignKeyKES (KES StandardCrypto)) =>
   MonadThrow m =>

--- a/kes-agent/src/Cardano/KESAgent/Protocols/Service/V2/Driver.hs
+++ b/kes-agent/src/Cardano/KESAgent/Protocols/Service/V2/Driver.hs
@@ -67,8 +67,6 @@ instance (MonadThrow m, MonadST m) => Serializable (DirectCodec m) KeyMessageTyp
 serviceDriver ::
   forall m f t p pr.
   VersionedProtocol (ServiceProtocol m) =>
-  HasInfo (DirectCodec m) (SignKeyKES (KES StandardCrypto)) =>
-  HasInfo (DirectCodec m) (VerKeyKES (KES StandardCrypto)) =>
   DirectDeserialise (SignKeyKES (KES StandardCrypto)) =>
   DirectSerialise (SignKeyKES (KES StandardCrypto)) =>
   MonadThrow m =>

--- a/kes-agent/src/Cardano/KESAgent/Serialization/DirectCodec.hs
+++ b/kes-agent/src/Cardano/KESAgent/Serialization/DirectCodec.hs
@@ -425,7 +425,6 @@ instance
   , DirectSerialise (SignKeyKES kes)
   , DirectDeserialise (SignKeyKES kes)
   , KESAlgorithm kes
-  , HasInfo (DirectCodec m) (SignKeyKES kes)
   ) =>
   Serializable (DirectCodec m) (SignKeyKES kes)
   where
@@ -461,7 +460,6 @@ instance
   , MonadST m
   , MonadThrow m
   , KESAlgorithm kes
-  , HasInfo (DirectCodec m) (VerKeyKES kes)
   ) =>
   Serializable (DirectCodec m) (VerKeyKES kes)
   where

--- a/kes-agent/test/Cardano/KESAgent/Tests/Simulation.hs
+++ b/kes-agent/test/Cardano/KESAgent/Tests/Simulation.hs
@@ -35,7 +35,6 @@ import Cardano.KESAgent.Processes.ServiceClient
 import Cardano.KESAgent.Protocols.RecvResult
 import Cardano.KESAgent.Protocols.StandardCrypto
 import Cardano.KESAgent.Protocols.VersionedProtocol
-import Cardano.KESAgent.Serialization.DirectCodec
 import Cardano.KESAgent.Util.Pretty
 import Cardano.KESAgent.Util.RefCounting
 
@@ -92,7 +91,6 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Proxy
-import Data.SerDoc.Class
 import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8)
 import Data.Time.Clock.POSIX (
@@ -189,8 +187,6 @@ type TestNetworkCrypto c =
 type TestNetworkContext m c =
   ( MonadTestNetwork m
   , TestNetworkCrypto c
-  , HasInfo (DirectCodec m) (VerKeyKES (KES c))
-  , HasInfo (DirectCodec m) (SignKeyKES (KES c))
   )
 
 testCrypto ::
@@ -199,10 +195,6 @@ testCrypto ::
   UnsoundKESAlgorithm kes =>
   TestNetworkCrypto c =>
   Show (SignKeyWithPeriodKES (KES c)) =>
-  HasInfo (DirectCodec IO) (VerKeyKES kes) =>
-  HasInfo (DirectCodec IO) (SignKeyKES kes) =>
-  (forall s. HasInfo (DirectCodec (IOSim s)) (VerKeyKES kes)) =>
-  (forall s. HasInfo (DirectCodec (IOSim s)) (SignKeyKES kes)) =>
   Proxy c ->
   Lock IO ->
   (forall a. (Show a, Pretty a) => Tracer IO a) ->


### PR DESCRIPTION
The `Serializable` instances for `SignKeyKES` and `VerKeyKES` each had a redundant SerDoc `HasInfo` constraint, which was leaking through to `ouroboros-consensus` -- this PR removes these constraints so consensus doesn't need to know about or depend on SerDoc at all.