### PR TITLE
Bump minimum version builds to support new versions of `typed-protocols` and `io-classes`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ repository cardano-haskell-packages
 
 -- run `nix flake lock --update-input hackageNix` after updating index-state.
 index-state:
-  hackage.haskell.org 2025-05-30T13:21:47Z,
-  cardano-haskell-packages 2025-05-28T12:02:33Z,
+  hackage.haskell.org 2025-07-02T11:58:57Z,
+  cardano-haskell-packages 2025-07-02T14:54:39Z,
 
 packages:
   kes-agent
@@ -25,7 +25,10 @@ package cryptonite
   -- generation is dubious. Set the flag so we use /dev/urandom by default.
   flags: -support_rdrand
 
-allow-newer: bytestring
+allow-newer:
+  bytestring,
+  serdoc-core:tasty-quickcheck,
+  tree-diff:QuickCheck,
 
 -- ---------------------------------------------------------
 -- Disable all tests by default

--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,6 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
--- run `nix flake lock --update-input hackageNix` after updating index-state.
 index-state:
   hackage.haskell.org 2025-07-02T11:58:57Z,
   cardano-haskell-packages 2025-07-02T14:54:39Z,
@@ -44,10 +43,3 @@ package kes-agent
 
 package cardano-crypto-class
   flags: +secp256k1-support
-
--- ---------------------------------------------------------
-
--- The two following one-liners will cut off / restore the remainder of this file (for nix-shell users):
--- when using the "cabal" wrapper script provided by nix-shell.
--- --------------------------- 8< --------------------------
--- Please do not put any `source-repository-package` clause above this line.

--- a/kes-agent/kes-agent.cabal
+++ b/kes-agent/kes-agent.cabal
@@ -124,7 +124,7 @@ library
                  , extra >=1.7.12 && <1.8
                  , formatting
                  , ghc-prim
-                 , io-classes >=1.5.0.0
+                 , io-classes >=1.8.0.0
                  , mtl
                  , network
                  , network-mux
@@ -138,7 +138,7 @@ library
                  , text
                  , template-haskell >=2.18.0.0
                  , time >=1.10
-                 , typed-protocols ^>=0.3
+                 , typed-protocols ^>=1.0
                  -- , typed-protocols-doc
     hs-source-dirs: src
     default-language: Haskell2010


### PR DESCRIPTION
- `typed-protocols`: 0.3 ➡️ 1.0
- `io-classes`: 1.5 ➡️ 1.8