### PR TITLE
add flake to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,34 @@
-cabal.project.local
+# Cabal
+.ghc.environment*
+tags
 dist-newstyle
 dist
-dist-build
+cabal-dev
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+cabal.project.local
+cabal.project.freeze
+
+# Stack
+.stack-work
+stack.yaml.lock
+
+# Haskell output files
+*.o
+*.hi
+*.dyn_o
+*.dyn_hi
+*.chi
+*.chs.h
+*.prof
+.liquid/
+
+# Nix
+result*
+pkgs/.cabal
+pkgs/.cache
+pkgs/.stack
+
+# Misc
+.pre-commit-config.yaml

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 repository cardano-haskell-packages
-  url: https://input-output-hk.github.io/cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
   secure: True
   root-keys:
     3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,821 @@
+{
+  "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752055566,
+        "narHash": "sha256-6iH3PscsCrrjoAi3ikVG+5isoLqeTCEo3DBS1uoUTv8=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-haskell-packages",
+        "rev": "ce0c1ca6c0fa40b522d68733c7da9cbd5f7d9a88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "blst": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.14",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752567835,
+        "narHash": "sha256-WCAXi4vnun4B0mUfEF+q5dm6oZvUtXotxB6N17XV4R0=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "df9f265e05e15385ac3c97f13098a5f0e8923905",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750897618,
+        "narHash": "sha256-MgzSJDtk9qXf+OYjqaGX7zebArRS236tgFKDAxV3OXw=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5ac996932a885bee0083893ba7a4727b654b7e8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": [
+          "hackage"
+        ],
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1750899099,
+        "narHash": "sha256-8Wy0VIdPoGd7JqaHT4ehfS87kW+xRn9XwSiRxu0nD9g=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "c16c3c648b3a2eef0cb1fb3706da801764d77565",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "iohk-nix": {
+      "inputs": {
+        "blst": "blst",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
+      },
+      "locked": {
+        "lastModified": 1750025513,
+        "narHash": "sha256-WUNoYIZvU9moc5ccwJcF22r+bUJXO5dWoRyLPs8bJic=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "f63aa2a49720526900fb5943db4123b5b8dcc534",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750543273,
+        "narHash": "sha256-WaswH0Y+Fmupvv8AkIlQBlUy/IdD3Inx9PDuE+5iRYY=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "a53c57c9a8d22a66a2f0c4c969e806da03f08c28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1748852332,
+        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "CHaP": "CHaP",
+        "flake-utils": "flake-utils",
+        "hackage": "hackage",
+        "haskell-nix": "haskell-nix",
+        "iohk-nix": "iohk-nix",
+        "nixpkgs": [
+          "haskell-nix",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750292027,
+        "narHash": "sha256-rmEsCxLWS/rAdIzZPSi0XbrY2BOztBlSHQHgYoXyovU=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "3f8c717e24953914821f1ddb4797dd768326faa6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "A flake for building the Cardano KES Agent";
+
+  inputs = {
+
+    haskell-nix = {
+      url = "github:input-output-hk/haskell.nix";
+      inputs.hackage.follows = "hackage";
+    };
+
+    nixpkgs.follows = "haskell-nix/nixpkgs";
+
+    hackage = {
+      url = "github:input-output-hk/hackage.nix";
+      flake = false;
+    };
+
+    CHaP = {
+      url = "github:IntersectMBO/cardano-haskell-packages?ref=repo";
+      flake = false;
+    };
+
+    iohk-nix = {
+      url = "github:input-output-hk/iohk-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs: inputs.flake-utils.lib.eachDefaultSystem (system: 
+    import ./nix/outputs.nix { inherit inputs system; }
+  );
+
+  nixConfig = {
+    extra-substituters = [ 
+      "https://cache.iog.io" 
+      "https://cache.zw3rk.com" 
+    ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk="
+    ];
+    allow-import-from-derivation = true;
+    accept-flake-config = true;
+  };
+}

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -1,0 +1,50 @@
+{ inputs, system }:
+
+let
+  inherit (pkgs) lib;
+
+  pkgs = import ./pkgs.nix { inherit inputs system; };
+
+  utils = import ./utils.nix { inherit pkgs lib; };
+
+  project = import ./project.nix { inherit inputs pkgs lib; };
+
+  mkShell = ghc: import ./shell.nix { inherit inputs pkgs lib project utils ghc; };
+
+  packages = { };
+
+  devShells = rec {
+    default = ghc966; 
+    ghc966 = mkShell "ghc966"; 
+    ghc984 = mkShell "ghc984"; 
+    ghc9102 = mkShell "ghc9102"; 
+    ghc9122 = mkShell "ghc9122"; 
+  };
+
+  projectFlake = project.flake {};
+
+  defaultHydraJobs = { 
+    ghc966 = projectFlake.hydraJobs.ghc966;
+    ghc984 = projectFlake.hydraJobs.ghc984;
+    ghc9102 = projectFlake.hydraJobs.ghc9102;
+    ghc9122 = projectFlake.hydraJobs.ghc9122;
+    inherit packages; 
+    inherit devShells;
+    required = utils.makeHydraRequiredJob hydraJobs; 
+  };
+
+  hydraJobsPerSystem = {
+    "x86_64-linux" = defaultHydraJobs; 
+    "x86_64-darwin" = defaultHydraJobs;
+    "aarch64-linux" = defaultHydraJobs; 
+    "aarch64-darwin" = defaultHydraJobs;
+  };
+
+  hydraJobs = utils.flattenDerivationTree "-" hydraJobsPerSystem.${system};
+in
+
+{
+  inherit packages;
+  inherit devShells;
+  inherit hydraJobs;
+}

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -11,7 +11,21 @@ let
 
   mkShell = ghc: import ./shell.nix { inherit inputs pkgs lib project utils ghc; };
 
-  packages = { };
+  exposed-haskell-packages = {
+    kes-agent-test = project.flake'.packages."kes-agent:test:kes-agent-tests";
+    kes-agent = project.flake'.packages."kes-agent:exe:kes-agent";
+    kes-service-client-demo = project.flake'.packages."kes-agent:exe:kes-service-client-demo";
+    kes-agent-control = project.flake'.packages."kes-agent:exe:kes-agent-control";
+  };
+
+  static-haskell-packages = {
+    # TODO: the pkgs.gitMinimal (needed for the kes-agent version command) at compile time gives an error for the musl64 build
+    # musl64-kes-agent = project.projectCross.musl64.hsPkgs.kes-agent.components.exes.kes-agent;
+  };
+
+  packages = 
+    exposed-haskell-packages //
+    static-haskell-packages;
 
   devShells = rec {
     default = ghc966; 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,13 @@
+{ inputs, system }:
+
+import inputs.nixpkgs {
+  inherit system;
+  config = inputs.haskell-nix.config;
+  overlays = [
+    inputs.iohk-nix.overlays.crypto
+    inputs.iohk-nix.overlays.cardano-lib
+    inputs.haskell-nix.overlay
+    inputs.iohk-nix.overlays.haskell-nix-crypto
+    inputs.iohk-nix.overlays.haskell-nix-extra
+  ];
+}

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -13,17 +13,55 @@ let
       src = lib.cleanSource ../.;
 
       flake.variants = {
-        ghc966 = {}; # Alias for the default variant
-        ghc984.compiler-nix-name = "ghc984";
-        ghc9102.compiler-nix-name = "ghc9102";
-        ghc9122.compiler-nix-name = "ghc9122";
+        ghc966 = {};
+
+        # Disabled other compilers for now, uncomment if needed
+        # but the dependencies pinned in the kes-agent.cabal 
+        # file are to strict for these versions
+
+        # ghc984.compiler-nix-name = "ghc984";
+        # ghc9102.compiler-nix-name = "ghc9102";
+        # ghc9122.compiler-nix-name = "ghc9122";
       };
 
       inputMap = { "https://chap.intersectmbo.org/" = inputs.CHaP; };
 
-      modules = [{
-        packages = {};
-      }];
+      modules = [
+        ({ pkgs, lib, config, ... }:
+          let
+            # A small helper function to generate post-install
+            # scripts for CLI tools to add completions
+            # to bash and zsh.
+            postInstallCompletion = exeName:  
+              "  BASH_COMPLETIONS=$out/share/bash-completion/completions\n  ZSH_COMPLETIONS=$out/share/zsh/site-functions\n  mkdir -p $BASH_COMPLETIONS $ZSH_COMPLETIONS\n  $out/bin/${exeName} --bash-completion-script ${exeName} > $BASH_COMPLETIONS/${exeName}\n  $out/bin/${exeName} --zsh-completion-script ${exeName} > $ZSH_COMPLETIONS/_${exeName}\n";
+          in 
+            # we need git at compile time since we use git to generate
+            # the version number in the binary
+            # Try `nix run .#kes-agent -- --version'
+            lib.mkIf (!pkgs.stdenv.hostPlatform.isWindows) {
+              packages.kes-agent.components.library.build-tools =
+                lib.mkForce [ pkgs.gitMinimal ];
+
+            # Wrap the test binary to have CLI tools in PATH
+            # This so that the E2E test can run with the CLI tools
+            packages.kes-agent.components.tests.kes-agent-tests.postInstall =
+              "  wrapProgram $out/bin/kes-agent-tests --set PATH ${
+                  lib.makeBinPath [
+                    config.hsPkgs.kes-agent.components.exes.kes-agent
+                    config.hsPkgs.kes-agent.components.exes.kes-agent-control
+                    config.hsPkgs.kes-agent.components.exes.kes-service-client-demo
+                  ]
+                }\n";
+
+            # Add completions for all CLI tools
+            packages.kes-agent.components.exes.kes-agent.postInstall =
+              postInstallCompletion "kes-agent";
+            packages.kes-agent.components.exes.kes-agent-control.postInstall =
+              postInstallCompletion "kes-agent-control";
+            packages.kes-agent.components.exes.kes-service-client-demo.postInstall =
+              postInstallCompletion "kes-service-client-demo";
+          })
+      ];
     }
   );
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,0 +1,32 @@
+{ inputs, pkgs, lib }:
+
+let
+  cabalProject = pkgs.haskell-nix.cabalProject' (
+    
+    { config, pkgs, ... }:
+
+    {
+      name = "kes-agent";
+
+      compiler-nix-name = lib.mkDefault "ghc966";
+
+      src = lib.cleanSource ../.;
+
+      flake.variants = {
+        ghc966 = {}; # Alias for the default variant
+        ghc984.compiler-nix-name = "ghc984";
+        ghc9102.compiler-nix-name = "ghc9102";
+        ghc9122.compiler-nix-name = "ghc9122";
+      };
+
+      inputMap = { "https://chap.intersectmbo.org/" = inputs.CHaP; };
+
+      modules = [{
+        packages = {};
+      }];
+    }
+  );
+
+in
+
+cabalProject

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,119 @@
+{ inputs, pkgs, lib, project, utils, ghc }:
+
+let
+
+  allTools = {
+    "ghc966".cabal                    = project.projectVariants.ghc966.tool "cabal" "latest";
+    "ghc966".cabal-fmt                = project.projectVariants.ghc966.tool "cabal-fmt" "latest";
+    "ghc966".haskell-language-server  = project.projectVariants.ghc966.tool "haskell-language-server" "latest";
+    "ghc966".stylish-haskell          = project.projectVariants.ghc966.tool "stylish-haskell" "latest";
+    "ghc966".fourmolu                 = project.projectVariants.ghc966.tool "fourmolu" "latest";
+    "ghc966".hlint                    = project.projectVariants.ghc966.tool "hlint" "latest";
+
+    "ghc984".cabal                    = project.projectVariants.ghc984.tool "cabal" "latest";
+    "ghc984".cabal-fmt                = project.projectVariants.ghc984.tool "cabal-fmt" "latest";
+    "ghc984".haskell-language-server  = project.projectVariants.ghc984.tool "haskell-language-server" "latest";
+    "ghc984".stylish-haskell          = project.projectVariants.ghc984.tool "stylish-haskell" "latest";
+    "ghc984".fourmolu                 = project.projectVariants.ghc984.tool "fourmolu" "latest";
+    "ghc984".hlint                    = project.projectVariants.ghc984.tool "hlint" "latest";
+
+    "ghc9102".cabal                   = project.projectVariants.ghc9102.tool "cabal" "latest";
+    "ghc9102".cabal-fmt               = project.projectVariants.ghc966.tool  "cabal-fmt" "latest"; # cabal-fmt not buildable with ghc9102
+    "ghc9102".haskell-language-server = project.projectVariants.ghc9102.tool "haskell-language-server" "latest";
+    "ghc9102".stylish-haskell         = project.projectVariants.ghc9102.tool "stylish-haskell" "latest";
+    "ghc9102".fourmolu                = project.projectVariants.ghc9102.tool "fourmolu" "latest";
+    "ghc9102".hlint                   = project.projectVariants.ghc9102.tool "hlint" "latest";
+
+    "ghc9122".cabal                   = project.projectVariants.ghc9122.tool "cabal" "latest";
+    "ghc9122".cabal-fmt               = project.projectVariants.ghc966.tool  "cabal-fmt" "latest"; # cabal-fmt not buildable with ghc9122
+    "ghc9122".haskell-language-server = project.projectVariants.ghc9122.tool "haskell-language-server" "latest";
+    "ghc9122".stylish-haskell         = project.projectVariants.ghc9122.tool "stylish-haskell" "latest";
+    "ghc9122".fourmolu                = project.projectVariants.ghc9122.tool "fourmolu" "latest";
+    "ghc9122".hlint                   = project.projectVariants.ghc9122.tool "hlint" "latest";
+  };
+
+  tools = allTools.${ghc};
+
+  preCommitCheck = inputs.pre-commit-hooks.lib.${pkgs.system}.run {
+
+    src = lib.cleanSources ../.;
+    
+    hooks = {
+      nixpkgs-fmt = {
+        enable = false;
+        package = pkgs.nixpkgs-fmt;
+      };
+      cabal-fmt = {
+        enable = false;
+        package = tools.cabal-fmt;
+      };
+      stylish-haskell = {
+        enable = false;
+        package = tools.stylish-haskell;
+        args = [ "--config" ".stylish-haskell.yaml" ];
+      };
+      fourmolu = {
+        enable = false;
+        package = tools.fourmolu;
+        args = [ "--mode" "inplace" ];
+      };
+      hlint = {
+        enable = false;
+        package = tools.hlint;
+        args = [ "--hint" ".hlint.yaml" ];
+      };
+      shellcheck = {
+        enable = false;
+        package = pkgs.shellcheck;
+      };
+    };
+  };
+
+  linuxPkgs = lib.optionals pkgs.hostPlatform.isLinux [
+  ];
+
+  darwinPkgs = lib.optionals pkgs.hostPlatform.isDarwin [
+  ];
+
+  commonPkgs = [
+    tools.haskell-language-server
+    tools.stylish-haskell
+    tools.fourmolu
+    tools.cabal
+    tools.hlint
+    tools.cabal-fmt
+
+    pkgs.shellcheck
+    pkgs.nixpkgs-fmt
+    pkgs.github-cli
+    pkgs.act
+    pkgs.bzip2
+    pkgs.gawk
+    pkgs.zlib
+    pkgs.cacert
+    pkgs.curl
+    pkgs.bash
+    pkgs.git
+    pkgs.which
+  ];
+
+  shell = project.shellFor {
+    name = "kes-agent-shell-${project.args.compiler-nix-name}";
+
+    buildInputs = lib.concatLists [
+      commonPkgs
+      darwinPkgs
+      linuxPkgs
+    ];
+
+    withHoogle = true;
+
+    shellHook = ''
+      ${preCommitCheck.shellHook}
+      export PS1="\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] "
+    '';
+  };
+
+in
+
+shell

--- a/nix/utils.nix
+++ b/nix/utils.nix
@@ -1,0 +1,37 @@
+{ pkgs, lib }:
+
+rec {
+
+  flattenDerivationTree = separator: set:
+    let
+      recurse = name: name':
+        flatten (if name == "" then name' else "${name}${separator}${name'}");
+
+      flatten = name': value:
+        let 
+          name = builtins.replaceStrings [":"] [separator] name';
+        in 
+          if lib.isDerivation value || lib.typeOf value != "set" then
+            [{ inherit name value; }]
+          else
+            lib.concatLists (lib.mapAttrsToList (recurse name) value);
+    in
+      assert lib.typeOf set == "set"; 
+      lib.listToAttrs (flatten "" set);
+
+
+  mapAttrsValues = f: lib.mapAttrs (_name: f);
+
+
+  makeHydraRequiredJob = hydraJobs:
+    let
+      cleanJobs = lib.filterAttrsRecursive 
+        (name: _: name != "recurseForDerivations")
+        (removeAttrs hydraJobs [ "required" ]);
+    in
+      pkgs.releaseTools.aggregate {
+        name = "required";
+        meta.description = "All jobs required to pass CI";
+        constituents = lib.collect lib.isDerivation cleanJobs;
+      };
+}


### PR DESCRIPTION
This PR adds the ability to build the project with Haskell.nix via the latest IOGX template. In particular, it adds the ability to build and run the executables and test suites,
```bash
.#kes-agent                .#kes-agent-control        .#kes-agent-tests          .#kes-service-client-demo
```
for example, via
```bash
nix run github:perturbing/kes-agent/perturbing/add-flake#kes-agent-tests
```
In addition, this PR adds autocompletion for the above two cli tools.