### PR TITLE
support contra-tracer 0.1.0.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ repository cardano-haskell-packages
 
 index-state:
   hackage.haskell.org 2025-08-05T15:28:56Z,
-  cardano-haskell-packages 2025-07-30T14:13:57Z,
+  cardano-haskell-packages 2025-09-16T18:21:39Z,
 
 packages:
   kes-agent

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1757088431,
-        "narHash": "sha256-yUv1JB7WOjoVWhEfk8cKap1P9QDn4hLd4ZHdkNoqvuY=",
+        "lastModified": 1758208099,
+        "narHash": "sha256-cC5qIRqNIt6bimx26CsgHpgSlb8He7wKrm4TYgKF+CY=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "8e043cb654d69e62bfb59b80afb2ddda8481f6f7",
+        "rev": "c877742df9822f85b0be5bd105a5f2c635f29a30",
         "type": "github"
       },
       "original": {

--- a/kes-agent-crypto/kes-agent-crypto.cabal
+++ b/kes-agent-crypto/kes-agent-crypto.cabal
@@ -40,7 +40,7 @@ library
                    Cardano.KESAgent.Util.RefCounting
     build-depends: aeson >=2.0
                  , bytestring >=0.11
-                 , cardano-crypto-class
+                 , cardano-crypto-class >=2.2
                  , cardano-binary
                    -- We need to pin this down to this exact version, because
                    -- there are two independent packages named contra-tracer:

--- a/kes-agent-crypto/kes-agent-crypto.cabal
+++ b/kes-agent-crypto/kes-agent-crypto.cabal
@@ -49,7 +49,7 @@ library
                    -- packages depending on the one in CHaP). Since the two
                    -- packages have the same name, we can only disambiguate
                    -- them by demanding a version that only one of them has.
-                 , contra-tracer ==0.1.0.1
+                 , contra-tracer ==0.1.0.1 || ==0.1.0.2
                  , io-classes
                  , nothunks
                  , quiet

--- a/kes-agent/kes-agent.cabal
+++ b/kes-agent/kes-agent.cabal
@@ -100,7 +100,7 @@ library
                  , binary
                  , blaze-html >=0.9 && <0.10
                  , bytestring >=0.11
-                 , cardano-crypto-class
+                 , cardano-crypto-class >=2.2
                  , cardano-binary
                    -- We need to pin this down to this exact version, because
                    -- there are two independent packages named contra-tracer:

--- a/kes-agent/kes-agent.cabal
+++ b/kes-agent/kes-agent.cabal
@@ -109,7 +109,7 @@ library
                    -- packages depending on the one in CHaP). Since the two
                    -- packages have the same name, we can only disambiguate
                    -- them by demanding a version that only one of them has.
-                 , contra-tracer ==0.1.0.1
+                 , contra-tracer ==0.1.0.1 || ==0.1.0.2
                  , containers >=0.6.5.1 && <0.9
                  , casing >=0.1.4.1 && <0.2
                  , extra >=1.7.12 && <1.9


### PR DESCRIPTION
This PR bumps the CHaP index-state and adds `contra-tracer ==0.1.0.2` as an acceptable dependency