### PR TITLE
Set lower bound for cardano-crypto-class to 2.2

### DIFF
--- a/kes-agent-crypto/kes-agent-crypto.cabal
+++ b/kes-agent-crypto/kes-agent-crypto.cabal
@@ -40,7 +40,7 @@ library
                    Cardano.KESAgent.Util.RefCounting
     build-depends: aeson >=2.0
                  , bytestring >=0.11
-                 , cardano-crypto-class
+                 , cardano-crypto-class >=2.2
                  , cardano-binary
                    -- We need to pin this down to this exact version, because
                    -- there are two independent packages named contra-tracer:

--- a/kes-agent/kes-agent.cabal
+++ b/kes-agent/kes-agent.cabal
@@ -100,7 +100,7 @@ library
                  , binary
                  , blaze-html >=0.9 && <0.10
                  , bytestring >=0.11
-                 , cardano-crypto-class
+                 , cardano-crypto-class >=2.2
                  , cardano-binary
                    -- We need to pin this down to this exact version, because
                    -- there are two independent packages named contra-tracer:


### PR DESCRIPTION
This PR adds a lower bound on `cardano-crypto-class` for `kes-agent` and `kes-agent-crypto`