### PR TITLE
Patches to compile with wasm32

### DIFF
--- a/kes-agent/kes-agent.cabal
+++ b/kes-agent/kes-agent.cabal
@@ -24,9 +24,11 @@ data-files: fixtures/*.vkey
           , fixtures/mainnet-shelley-genesis.json
 
 common project-config
+     if !arch(wasm32)
+         ghc-options:
+             -threaded
+             -rtsopts=all
      ghc-options:
-         -threaded
-         -rtsopts=all
          -haddock
          -Wunused-imports
 
@@ -94,6 +96,7 @@ library
                    Paths_kes_agent
     autogen-modules:
                    Paths_kes_agent
+
     build-depends: async
                  , aeson >=2.0
                  , base16-bytestring
@@ -118,23 +121,25 @@ library
                  , io-classes >=1.8.0.0
                  , kes-agent-crypto ^>= 0.1.0.0
                  , mtl
-                 , network
-                 , network-mux
                  , nothunks
                  , ouroboros-network-framework
                  , process >=1.6 && <1.7
                  , quiet
                  , serdoc-core
-                 , socket >= 0.8.3 && <0.9
                  , stm>=2.5 && <2.6
                  , text
                  , template-haskell >=2.18.0.0
                  , time >=1.10
                  , typed-protocols ^>=1.0 || ^>=1.1
                  -- , typed-protocols-doc
+    if !arch(wasm32)
+        build-depends: socket >= 0.8.3 && <0.9
+                     , network
+                     , network-mux
+
     hs-source-dirs: src
     default-language: Haskell2010
-    if os(windows)
+    if os(windows) || arch(wasm32)
     else
         build-depends: hsyslog
 
@@ -155,7 +160,6 @@ executable kes-agent
                  , directory
                  , filepath
                  , io-classes
-                 , network
                  , ouroboros-network-framework
                  , optparse-applicative
                  , serdoc-core
@@ -164,11 +168,14 @@ executable kes-agent
                  , tomland
                  , typed-protocols
                  , Win32-network
+    if arch(wasm32)
+        buildable: False
     if os(windows)
     else
         build-depends: unix
                      , hdaemonize
                      , hsyslog
+                     , network
 
 executable kes-service-client-demo
     import: project-config
@@ -189,6 +196,8 @@ executable kes-service-client-demo
                  , time
                  , typed-protocols
                  , Win32-network
+    if arch(wasm32)
+        buildable: False
     if os(windows)
     else
         build-depends: hsyslog
@@ -215,6 +224,8 @@ executable kes-agent-control
                  , time
                  , typed-protocols
                  , Win32-network
+    if arch(wasm32)
+        buildable: False
     if os(windows)
     else
         build-depends: hsyslog
@@ -266,6 +277,8 @@ test-suite kes-agent-tests
                  , text >=1.2.5
                  , time >=1.10
                  , Win32-network
+    if arch(wasm32)
+        buildable: False
     if os(windows)
     else
         build-depends: socket-unix >=0.2.0.0 && <0.3.0.0

--- a/kes-agent/src/Cardano/KESAgent/Priority.hs
+++ b/kes-agent/src/Cardano/KESAgent/Priority.hs
@@ -9,13 +9,13 @@ where
 
 import Cardano.KESAgent.Util.ColoredOutput
 
-#if !defined(mingw32_HOST_OS)
+#if !(defined(mingw32_HOST_OS) || defined(wasm32_HOST_ARCH))
 -- On POSIX, we'll just use the 'Priority' type from the @hsyslog@ package.
 import System.Posix.Syslog.Priority
 #endif
 
-#if defined(mingw32_HOST_OS)
--- On Windows, we'll define our own 'Priority' type as a drop-in replacement
+#if defined(mingw32_HOST_OS) || defined(wasm32_HOST_ARCH)
+-- On Windows and WebAssembly, we'll define our own 'Priority' type as a drop-in replacement
 -- for the syslog priority type from the @hsyslog@ package.
 data Priority
   = Emergency

--- a/kes-agent/src/Cardano/KESAgent/Processes/ServiceClient.hs
+++ b/kes-agent/src/Cardano/KESAgent/Processes/ServiceClient.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
@@ -108,10 +109,12 @@ formatDelayMicro us
       printf "%0.1fs" ((fromIntegral us :: Double) / 1_000_000)
   | us < 60_000_000 =
       printf "%0.0fs" ((fromIntegral us :: Double) / 1_000_000)
+#if !defined(wasm32_HOST_ARCH)
   | us < 3600_000_000 =
       printf "%i:$02i minutes" (us `div` 60_000_000) ((us `mod` 60_000_000) `div` 1_000_000)
   | otherwise =
       printf "%i:$02i hours" (us `div` 3600_000_000) ((us `mod` 3600_000_000) `div` 60_000_000)
+#endif
 
 instance Pretty ServiceClientTrace where
   pretty (ServiceClientDriverTrace d) = "Service: service driver: " ++ pretty d

--- a/kes-agent/src/Cardano/KESAgent/Util/PlatformPoison.hs
+++ b/kes-agent/src/Cardano/KESAgent/Util/PlatformPoison.hs
@@ -13,6 +13,8 @@ where
 poisonWindows :: Monad m => m ()
 #if defined(mingw32_HOST_OS)
 poisonWindows = error "This functionality is not supported on Windows"
+#elif defined(wasm32_HOST_ARCH)
+poisonWindows = error "This functionality is not supported on WebAssembly"
 #else
-poisonWindows = return()
+poisonWindows = return ()
 #endif

--- a/kes-agent/src/Cardano/KESAgent/Util/Version.hs
+++ b/kes-agent/src/Cardano/KESAgent/Util/Version.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Cardano.KESAgent.Util.Version
 where
 
+#if !defined(wasm32_HOST_ARCH)
 import Cardano.KESAgent.Util.GetVersion (getProgramVersion)
 import Language.Haskell.TH
+#endif
 
 libraryVersion :: String
+#if !defined(wasm32_HOST_ARCH)
 libraryVersion = $(litE =<< (stringL <$> runIO getProgramVersion))
+#else
+libraryVersion = "unknown"
+#endif


### PR DESCRIPTION
We're compiling `cardano-api` to WASM and need minor adjustments to `kes-agent` to make it build. These patches:  

This PR basically and conditionally to `wasm32` compilation:
- Disables executables and tests.
- Disables checks that are impossible because would overflow with 32bit.
- Disables the use of template Haskell for calculating the version because it is not supported as it is.

All changes are isolated to WASM builds and should have no impact elsewhere.

I am new to this codebase, so these are initial proposals. Happy to refine based on your feedback.

Thanks you