### PR TITLE
fix ci and hydra

### DIFF
--- a/kes-agent/kes-agent.cabal
+++ b/kes-agent/kes-agent.cabal
@@ -168,6 +168,7 @@ executable kes-agent
                  , tomland
                  , typed-protocols
                  , Win32-network
+                 , network
     if arch(wasm32)
         buildable: False
     if os(windows)
@@ -175,7 +176,6 @@ executable kes-agent
         build-depends: unix
                      , hdaemonize
                      , hsyslog
-                     , network
 
 executable kes-service-client-demo
     import: project-config

--- a/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
+++ b/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
@@ -63,6 +63,12 @@ makeMockGenesisFile dst = do
   let settings' = KeyMap.insert "systemStart" (JSON.toJSON systemStart) settings
   JSON.encodeFile dst settings'
 
+-- | a small helper function that creates a temporary directory with a short path
+-- than 'withSystemTempDirectory', which in combination with nix will create
+-- very long paths.
+withShortTmpDir :: (FilePath -> IO a) -> IO a
+withShortTmpDir = withTempDirectory "/tmp" "KesAgentTest"
+
 jsonResultToMaybe :: JSON.Result a -> IO a
 jsonResultToMaybe (JSON.Success a) = return a
 jsonResultToMaybe (JSON.Error err) = error $ "Invalid JSON: " ++ err
@@ -129,7 +135,7 @@ socketAddresses tmpdir =
 
 kesAgentFails :: Assertion
 kesAgentFails = do
-  (agentOutLines, agentErrLines, exitCode) <- withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  (agentOutLines, agentErrLines, exitCode) <- withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -164,7 +170,7 @@ kesAgentFails = do
 
 kesAgentGenesisFile :: Assertion
 kesAgentGenesisFile = do
-  (agentOutLines, agentErrLines, exitCode) <- withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  (agentOutLines, agentErrLines, exitCode) <- withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -196,7 +202,7 @@ kesAgentGenesisFile = do
 
 kesAgentNoControlAddress :: Assertion
 kesAgentNoControlAddress = do
-  (agentOutLines, agentErrLines, exitCode) <- withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  (agentOutLines, agentErrLines, exitCode) <- withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -246,7 +252,7 @@ logHandle h = do
 
 kesAgentControlInstallValid :: Assertion
 kesAgentControlInstallValid =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -301,7 +307,7 @@ kesAgentControlInstallValid =
 
 kesAgentControlUpdateValid :: Assertion
 kesAgentControlUpdateValid =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -388,7 +394,7 @@ kesAgentControlUpdateValid =
 
 kesAgentControlInstallInvalidOpCert :: Assertion
 kesAgentControlInstallInvalidOpCert =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
     opcertFile <- getDataFileName "fixtures/opcert.cert"
@@ -426,7 +432,7 @@ kesAgentControlInstallInvalidOpCert =
 
 kesAgentControlInstallNoKey :: Assertion
 kesAgentControlInstallNoKey =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         opcertFile = tmpdir </> "opcert.cert"
     kesKeyFile <- getDataFileName "fixtures/kes.vkey"
@@ -463,7 +469,7 @@ kesAgentControlInstallNoKey =
 
 kesAgentControlInstallDroppedKey :: Assertion
 kesAgentControlInstallDroppedKey =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         opcertFile = tmpdir </> "opcert.cert"
         kesKeyFile = tmpdir </> "kes.vkey"
@@ -524,7 +530,7 @@ kesAgentControlInstallDroppedKey =
 
 kesAgentControlDropInstalled :: Assertion
 kesAgentControlDropInstalled =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -606,7 +612,7 @@ kesAgentControlDropInstalled =
 
 kesAgentControlInstallMultiNodes :: Assertion
 kesAgentControlInstallMultiNodes =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -679,7 +685,7 @@ kesAgentControlInstallMultiNodes =
 
 kesAgentControlUpdateMultiNodes :: Assertion
 kesAgentControlUpdateMultiNodes =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -784,7 +790,7 @@ kesAgentControlUpdateMultiNodes =
 -- - Verify via control2.socket that the key is still there
 kesAgentKeySurvivesSighup :: Assertion
 kesAgentKeySurvivesSighup =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         controlAddr2 = tmpdir </> "control2.socket"
         kesKeyFile = tmpdir </> "kes.vkey"
@@ -860,7 +866,7 @@ kesAgentKeySurvivesSighup =
 
 kesAgentEvolvesKeyInitially :: Assertion
 kesAgentEvolvesKeyInitially =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -925,7 +931,7 @@ kesAgentEvolvesKeyInitially =
 
 kesAgentEvolvesKey :: Assertion
 kesAgentEvolvesKey =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let (controlAddr, serviceAddr) = socketAddresses tmpdir
         kesKeyFile = tmpdir </> "kes.vkey"
         opcertFile = tmpdir </> "opcert.cert"
@@ -1010,7 +1016,7 @@ kesAgentEvolvesKey =
 
 kesAgentPropagate :: Assertion
 kesAgentPropagate =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let controlAddr1 = tmpdir </> "control1.socket"
         serviceAddr1 = tmpdir </> "service1.socket"
         controlAddr2 = tmpdir </> "control2.socket"
@@ -1076,7 +1082,7 @@ kesAgentPropagate =
 
 kesAgentPropagateUpdate :: Assertion
 kesAgentPropagateUpdate =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let controlAddr1 = tmpdir </> "control1.socket"
         serviceAddr1 = tmpdir </> "service1.socket"
         controlAddr2 = tmpdir </> "control2.socket"
@@ -1181,7 +1187,7 @@ kesAgentPropagateUpdate =
 
 kesAgentSelfHeal1 :: Assertion
 kesAgentSelfHeal1 =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let controlAddr1 = tmpdir </> "control1.socket"
         serviceAddr1 = tmpdir </> "service1.socket"
         controlAddr2 = tmpdir </> "control2.socket"
@@ -1267,7 +1273,7 @@ kesAgentSelfHeal1 =
 
 kesAgentSelfHeal2 :: Assertion
 kesAgentSelfHeal2 =
-  withSystemTempDirectory "KesAgentTest" $ \tmpdir -> do
+  withShortTmpDir $ \tmpdir -> do
     let controlAddr1 = tmpdir </> "control1.socket"
         serviceAddr1 = tmpdir </> "service1.socket"
         controlAddr2 = tmpdir </> "control2.socket"

--- a/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
+++ b/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
@@ -302,7 +302,7 @@ kesAgentControlInstallValid =
           ExitSuccess
           ["KES key installed."]
         -- Allow some time for service client to actually receive the key
-        threadDelay 10_000
+        threadDelay 100_000
     assertMatchingOutputLinesWith
       ("SERVICE OUTPUT CHECK\n" {- <> (Text.unpack . Text.unlines $ agentOutLines) -})
       4
@@ -383,7 +383,7 @@ kesAgentControlUpdateValid =
           ExitSuccess
           ["KES key installed."]
         -- Allow some time for service client to actually receive the key
-        threadDelay 10_000
+        threadDelay 100_000
     assertMatchingOutputLinesWith
       ("SERVICE OUTPUT CHECK 1\n" {- <> (Text.unpack . Text.unlines $ agentOutLines) -})
       3
@@ -640,7 +640,7 @@ kesAgentControlInstallMultiNodes =
         (serviceOutLines1, ()) <- withService serviceAddr $ do
           -- Little bit of delay here to allow for the version handshake to
           -- finish
-          threadDelay 10_000
+          threadDelay 100_000
           return ()
         (serviceOutLines2, ()) <- withService serviceAddr $ do
           controlClientCheck
@@ -713,7 +713,7 @@ kesAgentControlUpdateMultiNodes =
         (serviceOutLines1, ()) <- withService serviceAddr $ do
           -- Little bit of delay here to allow for the version handshake to
           -- finish
-          threadDelay 10_000
+          threadDelay 100_000
           return ()
         (serviceOutLines2, ()) <- withService serviceAddr $ do
           controlClientCheck
@@ -1329,7 +1329,7 @@ kesAgentSelfHeal2 =
             ExitSuccess
             ["KES key installed."]
           -- Allow some time for agent to shut down cleanly
-          threadDelay 10_000
+          threadDelay 100_000
         controlClientCheckP
           "Connect"
           [ "info"
@@ -1353,7 +1353,7 @@ kesAgentSelfHeal2 =
             ExitSuccess
             (any (`elem` ["Current evolution: 0 / 64", "Current evolution: 1 / 64"]))
           -- Allow some time for agent to shut down cleanly
-          threadDelay 10_000
+          threadDelay 100_000
         return (agentOutLines2a ++ ["------"] ++ agentOutLines2b, ())
     return ()
 

--- a/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
+++ b/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
@@ -302,7 +302,7 @@ kesAgentControlInstallValid =
           ExitSuccess
           ["KES key installed."]
         -- Allow some time for service client to actually receive the key
-        threadDelay 100_000
+        threadDelay 300_000
     assertMatchingOutputLinesWith
       ("SERVICE OUTPUT CHECK\n" {- <> (Text.unpack . Text.unlines $ agentOutLines) -})
       4

--- a/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
+++ b/kes-agent/test/Cardano/KESAgent/Tests/EndToEnd.hs
@@ -63,11 +63,15 @@ makeMockGenesisFile dst = do
   let settings' = KeyMap.insert "systemStart" (JSON.toJSON systemStart) settings
   JSON.encodeFile dst settings'
 
--- | a small helper function that creates a temporary directory with a short path
--- than 'withSystemTempDirectory', which in combination with nix will create
--- very long paths.
+-- | Create a temporary directory with a short path on Unixy OSes to
+-- avoid Unix-domain socket path limits (esp. under nix on macOS).
+-- On Windows, fall back to the system temp directory.
 withShortTmpDir :: (FilePath -> IO a) -> IO a
+#if defined(mingw32_HOST_OS)
+withShortTmpDir = withSystemTempDirectory "KesAgentTest"
+#else
 withShortTmpDir = withTempDirectory "/tmp" "KesAgentTest"
+#endif
 
 jsonResultToMaybe :: JSON.Result a -> IO a
 jsonResultToMaybe (JSON.Success a) = return a

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -23,21 +23,21 @@ let
         package = pkgs.nixpkgs-fmt;
       };
       cabal-fmt = {
-        enable = true;
+        enable = false;
         package = tools.cabal-fmt;
       };
       stylish-haskell = {
-        enable = true;
+        enable = false;
         package = tools.stylish-haskell;
         args = [ "--config" ".stylish-haskell.yaml" ];
       };
       fourmolu = {
-        enable = true;
+        enable = false;
         package = tools.fourmolu;
         args = [ "--mode" "inplace" ];
       };
       hlint = {
-        enable = true;
+        enable = false;
         package = tools.hlint;
         args = [ "--hint" ".hlint.yaml" ];
       };


### PR DESCRIPTION
In #75 we accidentally removed `network` from the `kes-agent` executable, which broke the Windows build (`Network.Socket` not found).

This PR restores `network` as an unconditional dependency. Since the `kes-agent` executable is already `buildable: False` on `wasm32`, this change has no effect there.

This PR also disables the nix shell pre-commit checks that are not correctly configured currently.

This PR also fixes the long tmp dir errors that the nix builds get on darwin based builds.

This PR also tries to fix #55, though the `threadDelay` for the `kesAgentControlInstallValid` might still be set too low; time will tell.

@palas 