### PR TITLE
Bump Netowork for 10.7

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -58,6 +58,9 @@ if impl (ghc >= 9.14)
     , cborg:base
     , cborg:containers
 
+    -- https://github.com/well-typed/cborg/issues/373
+    , cborg-json:base
+
     -- https://github.com/haskellari/indexed-traversable/issues/49
     , indexed-traversable:base
     , indexed-traversable:containers

--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ repository cardano-haskell-packages
 
 index-state:
   , hackage.haskell.org 2026-02-19T00:44:22Z
-  , cardano-haskell-packages 2026-02-18T15:43:28Z
+  , cardano-haskell-packages 2026-03-07T10:30:57Z
 
 packages:
   kes-agent

--- a/cabal.project
+++ b/cabal.project
@@ -40,14 +40,6 @@ package kes-agent
 package cardano-crypto-class
   flags: +secp256k1-support
 
-source-repository-package
-  type: git
-  location: https://github.com/IntersectMBO/ouroboros-network
-  tag: 92bcc0f6e4db68bd5a6026d5c81d18e418ae44b4
-  --sha256: 0ijaykvjd1lsw5fmyrxbfhzwgfmvhvpma31g0binbggjrnsrnfnb
-  subdir: network-mux
-          ouroboros-network
-
 -- cabal-allow-newer
 if impl (ghc >= 9.14)
   allow-newer:

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1771430981,
-        "narHash": "sha256-0Zw5VSz9ApokGrVgamdCozLIWONmORdgGHL/DaoxHFA=",
+        "lastModified": 1772900098,
+        "narHash": "sha256-KAoFZXGDNMZnaVNHcZzGnwirXYuSQ6bwSrEqjlfYJj0=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "14d58c151f11c48e8c3ed9378c5cbed4ba5de277",
+        "rev": "3ed94afe1ca8c75d2d20bb040863b403c07b36d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates the CHaP and index state and removes the SRP on `ouroboros-netowork`.

Cabal build plan diff:
```diff
Package versions
~~~~~~~~~~~~~~~~

+atomic-primops-0.8.8 lib
+cborg-json-0.2.6.0 lib
+conduit-1.3.6.1 lib
+ekg-core-0.1.2.0 lib
+hostname-1.0 lib
+http-date-0.0.11 lib
+libyaml-0.1.4 lib
+libyaml-clib-0.2.5 lib
+mono-traversable-1.0.21.0 lib
-network-mux-0.10.0.0 lib
+network-mux-0.10.1.0 lib
-network-mux-0.10.0.0 exe:mux-demo
+network-mux-0.10.1.0 exe:mux-demo
-network-mux-0.10.0.0 exe:mux-leios-demo
+network-mux-0.10.1.0 exe:mux-leios-demo
-ouroboros-network-0.24.0.0 lib
+ouroboros-network-1.0.0.0 lib
-ouroboros-network-0.24.0.0 lib:api
+ouroboros-network-1.0.0.0 lib:api
-ouroboros-network-0.24.0.0 lib:api-tests-lib
+ouroboros-network-1.0.0.0 lib:api-tests-lib
-ouroboros-network-0.24.0.0 lib:framework
+ouroboros-network-1.0.0.0 lib:framework
-ouroboros-network-0.24.0.0 lib:framework-tests-lib
+ouroboros-network-1.0.0.0 lib:framework-tests-lib
+ouroboros-network-1.0.0.0 lib:framework-tracing
-ouroboros-network-0.24.0.0 lib:orphan-instances
+ouroboros-network-1.0.0.0 lib:orphan-instances
-ouroboros-network-0.24.0.0 lib:ouroboros-network-tests-lib
+ouroboros-network-1.0.0.0 lib:ouroboros-network-tests-lib
-ouroboros-network-0.24.0.0 lib:protocols
+ouroboros-network-1.0.0.0 lib:protocols
-ouroboros-network-0.24.0.0 lib:protocols-tests-lib
+ouroboros-network-1.0.0.0 lib:protocols-tests-lib
-ouroboros-network-0.24.0.0 lib:tests-lib
+ouroboros-network-1.0.0.0 lib:tests-lib
+ouroboros-network-1.0.0.0 lib:tracing
-ouroboros-network-0.24.0.0 exe:demo-connection-manager
+ouroboros-network-1.0.0.0 exe:demo-connection-manager
-ouroboros-network-0.24.0.0 exe:demo-ping-pong
+ouroboros-network-1.0.0.0 exe:demo-ping-pong
-quickcheck-monoids-0.1.0.3 lib
+quickcheck-monoids-0.1.1.0 lib
+time-manager-0.3.1.1 lib
+trace-dispatcher-2.11.1 lib
+unagi-chan-0.4.1.4 lib
+unix-compat-0.7.4.1 lib
+unliftio-0.2.25.1 lib
+yaml-0.11.11.2 lib
```