### PR TITLE
Release `kes-agent-1.2.0.0` and `kes-agent-crypto-1.1.0.0`

### DIFF
--- a/kes-agent-crypto/CHANGELOG.md
+++ b/kes-agent-crypto/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for kes-agent-crypto
 
+## 1.1.0.0 -- 2026-03-13
+
+### Breaking
+
+- Update to `cardano-crypto-class-2.3.1.0`
+
 ## 1.0.0.0 -- 2026-01-09
 
 - First major release. See `kes-agent`'s `CHANGELOG.md` for details.

--- a/kes-agent-crypto/kes-agent-crypto.cabal
+++ b/kes-agent-crypto/kes-agent-crypto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               kes-agent-crypto
-version:            1.0.0.0
+version:            1.1.0.0
 synopsis: KES agent crypto library
 -- description:
 license:            Apache-2.0

--- a/kes-agent/CHANGELOG.md
+++ b/kes-agent/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog - Kes Agent
 
+## [v1.2.0.0]
+
+### Breaking
+
+- Update to `cardano-crypto-class-2.3.1.0`
+- Update to `typed-protocols-1.2`
+
+### Non-Breaking
+
+- Allow `random-1.3.*`
+
 ## [v1.1.0.0]
 
 - This version adds support for `ouroboros-network-0.24.0.0`. Older versions of `ouroboros-network` (and its associated packages) are no longer supported.

--- a/kes-agent/kes-agent.cabal
+++ b/kes-agent/kes-agent.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: kes-agent
-version: 1.1.0.0
+version: 1.2.0.0
 
 synopsis: KES agent library and binaries
 description: KES agent provides a solution for storing KES keys


### PR DESCRIPTION
CHaP CI passes: https://github.com/IntersectMBO/cardano-haskell-packages/pull/1291