### PR TITLE
Improve docs flagged as high-impact in the May 2026 SPO feedback form.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ stored in memory, rather than on disk, and will manage the evolution of KES keys
 in place of the node, allowing for the keys to persist (in ephemeral storage)
 even over a restart of the node itself.
 
-For further information, see [the Guide](doc/guide.markdown).
+## Documentation
+
+- [User Guide](doc/guide.markdown) — concepts, installation, configuration, and
+  recommended setups (includes a glossary, Restart & Recovery, and a
+  known-good-state checklist).
+- [Migration guide](doc/migration.markdown) — moving an existing block producer
+  from an on-disk KES key to the agent.
+- [Troubleshooting](doc/troubleshooting.markdown) — common situations, log
+  filters, and how to tell a real problem from a harmless warning.
+- [FAQ](doc/faq.markdown) — design rationale and security model.
 
 ## OS Compatibility
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,18 @@
+# KES Agent Documentation
+
+Not sure where to start? Use this table.
+
+| If you want to… | Read |
+|-----------------|------|
+| Understand what the KES Agent is and how it works, install it, and see recommended deployment setups | [User Guide](guide.markdown) |
+| Move an existing block producer from an on-disk KES key to the agent | [Migration Guide](migration.markdown) |
+| Diagnose a problem, read logs, or tell a real error from a harmless warning | [Troubleshooting](troubleshooting.markdown) |
+| Understand the design rationale and security model (why keys aren't on disk, what survives a reboot, etc.) | [FAQ](faq.markdown) |
+
+## Quick links within the guide
+
+- [Glossary](guide.markdown#glossary) — staged vs. installed key, service vs. control socket, OpCert, host roles
+- [Installation](guide.markdown#installation) — build prerequisites, tarball, Docker, building from source
+- [Restart & Recovery](guide.markdown#restart--recovery) — what survives a node restart, agent restart, or full reboot
+- [Verifying a correct setup](guide.markdown#verifying-a-correct-setup-known-good-state) — known-good-state checklist
+- [Recommended Setups](guide.markdown#recommended-setups) — single-agent, backup-agent, and multi-agent topologies

--- a/doc/faq.markdown
+++ b/doc/faq.markdown
@@ -79,6 +79,26 @@ restarts, it will connect to the agent again after restarting, and the agent
 will serve the current evolution of the KES key, after which the node can start
 forging blocks.
 
+### What happens when the KES agent restarts (but the node keeps running)?
+
+The agent holds its KES key only in memory, so when the agent process restarts
+it loses that key. The node, however, is unaffected for the moment: once it has
+received a key it evolves it autonomously and keeps forging blocks on its own,
+without needing the agent — it only needs the agent again the next time it
+restarts, or when you push a brand-new key.
+
+What you need to do depends on the topology:
+
+- In a **single-agent** setup, the restarted agent comes back up empty, so you
+  must install a key into it again (generate a staged key, issue an OpCert, and
+  install it) before the node next restarts.
+- In a **backup-agent** (multi-agent) setup, the restarted agent reconnects to
+  its bootstrap peer and is served the current key automatically, so no manual
+  intervention is required.
+
+This is the same trade-off described in the guide's *Restart & Recovery*
+section.
+
 ### What happens when the entire server reboots?
 
 In this case, a KES agent running on the same server will terminate, and the

--- a/doc/guide.markdown
+++ b/doc/guide.markdown
@@ -45,6 +45,47 @@ sending keys over a network socket, we do it such that the keys are moved
 directly between mlocked memory and the socket file descriptors, without using
 any intermediate data structures for serialization/deserialization.
 
+Glossary
+--------
+
+If you are new to the KES Agent, these are the terms used throughout this guide
+and the CLI output. They are explained in more depth in the sections that
+follow.
+
+- **KES key**: the "hot" Key Evolving Signature key used by a block-forging
+  node to sign blocks. It exists in two parts: the **KES sign key** (secret,
+  must never touch disk) and the **KES verification key** (public, used to build
+  an OpCert).
+- **KES period**: a ~36-hour window. The node evolves the KES sign key once per
+  period and deletes the previous evolution; this is what provides forward
+  security.
+- **Cold key**: the long-lived identity key of the pool, kept on an air-gapped
+  signing host. The **cold sign key** signs OpCerts and must never leave that
+  host; the **cold verification key** (`cold.vkey`) is public and is used by the
+  agent to verify OpCerts.
+- **OpCert (operational certificate)**: a certificate, signed by the cold key,
+  that authorises a particular KES verification key (with a serial number and a
+  start KES period). It is what binds a KES key to your pool identity.
+- **Staged key**: a freshly generated KES key held in the agent's staging area.
+  It is *not yet active* and is not served to nodes — it is waiting for a
+  matching OpCert.
+- **Installed (active) key**: the KES key the agent has verified against an
+  OpCert and is actively serving to connected nodes. When `kes-agent-control
+  info` reports an *Installed KES SignKey*, this is what it means.
+- **Service socket**: the socket on which the agent *serves keys*. Nodes (and
+  other agents) connect here. Configured on the node with
+  `--shelley-kes-agent-socket`.
+- **Control socket**: the socket on which the agent *receives commands* from the
+  `kes-agent-control` CLI (generate, install, drop keys, query info).
+- **Bootstrap peer**: another agent this agent connects to in order to *receive*
+  a key copy, providing redundancy. See
+  [Recommended Setups](#recommended-setups) and the
+  [Troubleshooting guide](troubleshooting.markdown).
+- **Host roles**: the **node host** runs `cardano-node` and (usually) an agent;
+  the **control host** runs `kes-agent-control`; the air-gapped **signing host**
+  holds the cold sign key and issues OpCerts. These may be three machines or, in
+  the simplest setup, fewer.
+
 Design Overview
 ---------------
 
@@ -195,19 +236,88 @@ provide one, mount it into the container, like so:
 #### Build Prerequisites
 
 - The `git` version control system
-- The `gcc` compiler, including C++ support
-- Developer libraries for `libsodium`
-- Developer libraries for `secp256k1` (https://github.com/bitcoin-core/secp256k1)
-- Developer libraries for `libblst` (https://github.com/supranational/blst).
-  Note that installation requires some undocumented manual steps:
-  - Copying the headers into an appropriate system-wide location
-    (`/usr/local/include/`).
-  - Copying the library `libblst.a` into an appropriate system-wide location
-    (`/usr/local/lib/`).
-  - Creating a `pkgconf` entry so that the build tooling can find the library.
-  - Running `ldconf` to register the library with the system-wide linker.
-- GHC, the Haskell compiler
-- The Haskell build tool, Cabal
+- The `gcc` compiler, including C++ support (and `make`, `autoconf`, `libtool`,
+  `pkg-config`)
+- GHC, the Haskell compiler, and the Haskell build tool, Cabal (we recommend
+  installing both via [GHCup](https://www.haskell.org/ghcup/))
+- The C cryptography libraries `libsodium` (IOG fork), `secp256k1`, and
+  `libblst`, described below.
+
+These are **exactly the same C cryptography libraries that `cardano-node`
+requires** — including the IOG fork of `libsodium`, not the stock distribution
+package. The authoritative, maintained instructions live in the Cardano
+developer portal, under
+[Installing cardano-node → C library dependencies](https://developers.cardano.org/docs/get-started/infrastructure/node/installing-cardano-node/#c-library-dependencies);
+follow that page and keep the versions in sync with the `cardano-node` release
+you are targeting.
+
+**If you already build `cardano-node` from source on this host, these libraries
+are already installed and you can skip this section.**
+
+For convenience, the commands below mirror that guide. They use version
+variables pinned by `iohk-nix` (`IOHKNIX_VERSION`, `SODIUM_VERSION`,
+`SECP256K1_VERSION`, `BLST_VERSION`); set them as shown in the developer-portal
+guide so you build the exact revisions `cardano-node` expects.
+
+```sh
+mkdir -p ~/src && cd ~/src
+```
+
+**`libsodium` (IOG fork):**
+
+```sh
+git clone https://github.com/intersectmbo/libsodium
+cd libsodium && git checkout $SODIUM_VERSION
+./autogen.sh && ./configure
+make && sudo make install
+cd ~/src
+```
+
+**`secp256k1`:**
+
+```sh
+git clone --depth 1 --branch ${SECP256K1_VERSION} https://github.com/bitcoin-core/secp256k1
+cd secp256k1
+./autogen.sh && ./configure --enable-module-schnorrsig --enable-experimental
+make && sudo make install
+cd ~/src
+```
+
+The `--enable-module-schnorrsig --enable-experimental` flags are required; the
+library will build without them but Cardano code will fail to link.
+
+**`libblst`:** upstream does not ship an installer, so the headers, the static
+library, and a `pkg-config` entry must be placed by hand:
+
+```sh
+git clone --depth 1 --branch ${BLST_VERSION} https://github.com/supranational/blst
+cd blst && ./build.sh
+cat > libblst.pc << EOF
+prefix=/usr/local
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+Name: libblst
+Description: Multilingual BLS12-381 signature library
+URL: https://github.com/supranational/blst
+Version: ${BLST_VERSION#v}
+Cflags: -I\${includedir}
+Libs: -L\${libdir} -lblst
+EOF
+sudo cp libblst.pc /usr/local/lib/pkgconfig/
+sudo cp bindings/blst_aux.h bindings/blst.h bindings/blst.hpp /usr/local/include/
+sudo cp libblst.a /usr/local/lib
+sudo chmod u=rw,go=r /usr/local/{lib/{libblst.a,pkgconfig/libblst.pc},include/{blst.{h,hpp},blst_aux.h}}
+cd ~/src
+```
+
+Finally, make sure the dynamic linker and `pkg-config` can find the libraries
+you just installed (add these to your shell profile to make them permanent):
+
+```sh
+export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
 
 #### Building KES Agent
 
@@ -221,6 +331,29 @@ provide one, mount it into the container, like so:
     cabal update
     cabal install exe:kes-agent exe:kes-agent-control
     ```
+
+##### Building on one host and installing on another
+
+You usually do **not** want to install GHC, Cabal, and the build toolchain on a
+hardened block producer. Instead, build on a separate workstation that runs the
+**same OS and architecture** as the block producer, then copy the binaries
+across.
+
+The repository ships a helper that builds `kes-agent` and packages it together
+with the systemd unit files and `install.sh` into a versioned tarball:
+
+```sh
+./scripts/make-release-bundle.sh
+# produces dist/kes-agent-<version>-<arch>.tar.gz
+```
+
+Copy that tarball to the target host, unpack it, and run the bundled
+`./install.sh` (see [Using a tarball](#using-a-tarball)). Note that the binaries
+are dynamically linked against `libsodium` and `secp256k1`, so the **same shared
+libraries must also be present on the target host** (`libblst` is linked
+statically and does not need to be installed there). The build and target hosts
+must have compatible `glibc` versions; building on the same OS release as the
+target is the simplest way to guarantee this.
 
 #### Installing KES Agent
 
@@ -302,9 +435,14 @@ Now:
 
 ### Configuring `cardano-node` To Use The KES Agent
 
-The only difference from the usual procedure is using the new flag 
+> **Migrating an existing block producer?** For a complete, ordered walkthrough
+> of moving a node that currently uses a `kes.skey` file on disk over to the
+> agent — including the foreground-to-systemd transition — see the
+> [Migration guide](migration.markdown).
+
+The only difference from the usual procedure is using the new flag
 `--shelley-kes-agent-socket SERVICE_SOCKET_PATH` instead of using the kes.skey
-from file. 
+from file.
 
 ```shell
 cardano-node run \
@@ -460,6 +598,59 @@ Command Reference
 
 The full list of command line options for `kes-agent` and `kes-agent-control`
 can be printed using the `--help` option.
+
+Restart & Recovery
+------------------
+
+**Read this before going to production.** Because the KES sign key lives only in
+memory, *what survives a restart depends on which process restarts*. The three
+cases below behave very differently, and confusing them is the most common
+source of operator error.
+
+A node that has already received a valid KES key evolves it autonomously and can
+keep forging blocks until that key reaches the end of its evolutions — even if
+the agent is temporarily unavailable. A node only needs a working agent
+connection **at startup** (and when you push a brand-new key). This is why a
+brief agent outage does not, by itself, stop block production.
+
+| Event | In-memory KES key | What you must do |
+|-------|-------------------|------------------|
+| **`cardano-node` process restarts** (agent stays up) | Agent keeps the key. | Nothing. The node reconnects to the service socket, is re-served the current evolution, and resumes forging automatically. |
+| **KES agent restarts** (node stays up) | Agent **loses** its key. | **Single-agent:** reinstall a key (`gen-staged-key` → OpCert → `install-key`). The node keeps forging in the meantime on the key it already holds. **Backup-agent:** the restarted agent reconnects to its bootstrap peer and is re-served the key automatically (self-healing) — no action needed. |
+| **Full host reboot** | Both agent and node lose their in-memory keys. | **Single-agent:** reinstall a key, then the node reconnects and is re-served. **Backup-agent on a separate host:** the surviving agent still holds the key; the rebooted agent bootstraps from it and the node reconnects automatically. |
+
+In short: a **single-agent** setup trades a small amount of availability for
+simplicity — an agent restart or host reboot requires a manual key
+re-installation. A **backup-agent** setup (see
+[Recommended Setups](#recommended-setups)) self-heals across these events at the
+cost of extra moving parts. See also the
+[FAQ](faq.markdown#design-considerations) and the
+[Troubleshooting guide](troubleshooting.markdown).
+
+Verifying A Correct Setup (Known-Good State)
+--------------------------------------------
+
+After migrating a node to the KES agent (or after any recovery action), run
+through this checklist. When every item passes, the node is correctly forging
+through the agent:
+
+- [ ] `kes-agent-control info` reports an **Installed KES SignKey** (not only a
+      staged key).
+- [ ] The verification key shown by `kes-agent-control info` matches the KES
+      verification key in the OpCert the node is using.
+- [ ] The `cardano-node` process is started with
+      `--shelley-kes-agent-socket` (pointing at the agent's service socket).
+- [ ] The `cardano-node` process **no longer** uses `--shelley-kes-key` and no
+      `kes.skey` file is referenced on the block producer.
+- [ ] The node logs show `Forge.Loop.StartLeadershipCheck` (leadership checks
+      are running).
+- [ ] The node logs show KES info with sane `startPeriod` / `currPeriod` /
+      `endPeriod` values, and `currPeriod` is within the start/end range.
+- [ ] `cardano-cli query tip` works and reports `syncProgress` of `100.00`.
+- [ ] The `kes-agent` systemd service is `active` (in a production systemd
+      setup).
+
+If any item fails, see the [Troubleshooting guide](troubleshooting.markdown).
 
 Recommended Setups
 ------------------

--- a/doc/migration.markdown
+++ b/doc/migration.markdown
@@ -1,0 +1,209 @@
+Migrating An Existing Block Producer To The KES Agent
+=====================================================
+
+This guide walks through moving a running block-producing `cardano-node` from a
+KES sign key **on disk** (`--shelley-kes-key kes.skey`) to receiving its key
+from a KES agent over a socket (`--shelley-kes-agent-socket`).
+
+It is written against the components every operator runs directly —
+`cardano-node`, `cardano-cli`, and `kes-agent` / `kes-agent-control` — using
+their real flags. If you manage your node through a wrapper or orchestration
+script, use this as the authoritative reference and adapt your tooling
+accordingly.
+
+Before you start, make sure you understand the [Glossary](guide.markdown#glossary)
+(staged vs. installed key, service vs. control socket) and the
+[Restart & Recovery](guide.markdown#restart--recovery) behaviour — the KES sign
+key lives **only in memory**, which changes how restarts and reboots behave.
+
+Prerequisites
+-------------
+
+- `cardano-node` 11.x (it supports `--shelley-kes-agent-socket`).
+- `kes-agent` and `kes-agent-control` installed on the node host (see
+  [Installation](guide.markdown#installation)).
+- Your cold **verification** key (`cold.vkey`) available on the node host — the
+  agent needs it to verify OpCerts.
+- An air-gapped signing host that holds the cold **sign** key (`cold.skey`) and
+  the OpCert issue counter (`opcert.counter`). See
+  [Setting Up An Air-gapped Signing Host](guide.markdown#setting-up-an-air-gapped-signing-host).
+- Your existing `vrf.skey` (unchanged by this migration).
+
+> **A note on the OpCert counter.** Migrating installs a **new** KES key, which
+> means issuing a **new** OpCert with the next serial number. Always issue
+> OpCerts from the air-gapped host's `opcert.counter` so the serial number keeps
+> increasing; an out-of-order serial will be rejected.
+
+Read this before you begin
+--------------------------
+
+A few ordering rules prevent the most common mistakes:
+
+- **The KES sign key lives only in memory.** Restarting the agent before a key
+  is installed leaves it empty.
+- **Do the steps in order.** Generate the staged key → issue the OpCert →
+  install the key → *then* point the node at the agent. If you switch the node
+  to the agent socket before a key is installed, the node will have no key to
+  forge with.
+- **Do not delete your old `kes.skey` until the migration is verified.** Keep it
+  until the node is confirmed forging through the agent (see the
+  [Known-good-state checklist](guide.markdown#verifying-a-correct-setup-known-good-state)),
+  so you can roll back if needed.
+
+Step 1 — Start the KES agent
+----------------------------
+
+For the first run it is convenient to start the agent in the foreground so you
+can watch its output. (We move it to a systemd service at the end.)
+
+```sh
+kes-agent run \
+  -s service.socket \
+  -c control.socket \
+  --cold-verification-key cold.vkey \
+  --genesis-file mainnet-shelley-genesis.json
+```
+
+Leave this running and open a second shell for the control commands. Point
+`kes-agent-control` at the control socket either with `-c control.socket` on
+each command, or by exporting it once:
+
+```sh
+export KES_AGENT_CONTROL_PATH=control.socket
+```
+
+Step 2 — Generate a staged KES key (control host)
+-------------------------------------------------
+
+First work out the current KES period (needed for the OpCert):
+
+```sh
+# slots per KES period, from the genesis file:
+grep KESPeriod mainnet-shelley-genesis.json
+# "slotsPerKESPeriod": 3600,
+
+# current tip:
+cardano-cli query tip --mainnet
+# ... "slot": 26633911, ...
+
+# current KES period = slot / slotsPerKESPeriod:
+expr 26633911 / 3600
+# 7398
+```
+
+Generate a staged key; this writes the matching verification key to a file:
+
+```sh
+kes-agent-control gen-staged-key \
+  --kes-verification-key-file kes.vkey
+```
+
+Copy `kes.vkey` to your secure removable storage device and carry it to the
+air-gapped signing host.
+
+Step 3 — Issue an OpCert (air-gapped signing host)
+--------------------------------------------------
+
+```sh
+cardano-cli node issue-op-cert \
+  --kes-verification-key-file kes.vkey \
+  --cold-signing-key-file cold.skey \
+  --operational-certificate-issue-counter opcert.counter \
+  --kes-period 7398 \
+  --out-file opcert.cert
+```
+
+Copy `opcert.cert` back to the secure removable storage device and return it to
+the control host. **Do not copy the cold sign key off this host.**
+
+Step 4 — Install the key (control host)
+---------------------------------------
+
+```sh
+kes-agent-control install-key --opcert-file opcert.cert
+```
+
+The agent verifies the OpCert against the staged key, promotes it to the
+**installed (active)** key, and serves it to any connected nodes.
+
+Step 5 — Verify the agent holds an active key
+---------------------------------------------
+
+```sh
+kes-agent-control info
+```
+
+Confirm the output reports an **Installed KES SignKey** (not just a staged key).
+
+Step 6 — Point cardano-node at the agent
+-----------------------------------------
+
+Change the node's start command: remove the on-disk key flag
+(`--shelley-kes-key kes.skey`) and add `--shelley-kes-agent-socket`, pointing it
+at the agent's **service** socket. Update `--shelley-operational-certificate` to
+the **new** `opcert.cert` you just issued. The VRF key is unchanged.
+
+```sh
+cardano-node run \
+  --config                          configuration.yaml \
+  --topology                        topology.json \
+  --database-path                   db \
+  --socket-path                     node.sock \
+  --shelley-kes-agent-socket        service.socket \
+  --shelley-vrf-key                 vrf.skey \
+  --shelley-operational-certificate opcert.cert \
+  --port                            3001
+```
+
+Step 7 — Restart cardano-node
+-----------------------------
+
+Restart the node so it picks up the new command. On startup it connects to the
+agent's service socket and is served the current evolution of the KES key.
+
+Step 8 — Verify the migration
+-----------------------------
+
+Work through the
+[Known-good-state checklist](guide.markdown#verifying-a-correct-setup-known-good-state).
+When every item passes, the migration is complete. Only then is it safe to
+securely remove the old `kes.skey` from the block producer.
+
+Moving the agent into a systemd service
+---------------------------------------
+
+The foreground agent above is fine for the first migration, but for production
+you want the agent managed by systemd so it starts on boot and is supervised.
+See [Installing KES Agent](guide.markdown#installing-kes-agent) for the unit
+files and `install.sh`.
+
+Be aware of one subtlety that surprises operators: **the systemd agent is a
+separate process from your foreground agent, with its own (empty) memory.**
+Starting the service does not transfer the key from the foreground agent. So:
+
+1. Stop the foreground agent (Ctrl-C in its shell).
+2. Start the systemd service (`systemctl start kes-agent`). It comes up with no
+   key.
+3. Install a key into it exactly as in Steps 2–5, using the systemd agent's
+   control socket path.
+4. Restart `cardano-node` so it reconnects to the service socket the systemd
+   agent listens on.
+
+Do **not** configure the temporary foreground agent as a permanent bootstrap
+peer of the systemd agent — it will not exist after the migration, and a dead
+bootstrap peer left in the configuration will show as permanently
+`connecting...` in `kes-agent-control info` (this is harmless but looks alarming;
+see the [Troubleshooting guide](troubleshooting.markdown)).
+
+If you want an agent that survives reboots without manual re-installation,
+configure a **backup agent** on a second host instead (see
+[Recommended Setups](guide.markdown#recommended-setups) and
+[Restart & Recovery](guide.markdown#restart--recovery)).
+
+See also
+--------
+
+- [Restart & Recovery](guide.markdown#restart--recovery)
+- [Known-good-state checklist](guide.markdown#verifying-a-correct-setup-known-good-state)
+- [Troubleshooting guide](troubleshooting.markdown)
+- [FAQ](faq.markdown)

--- a/doc/troubleshooting.markdown
+++ b/doc/troubleshooting.markdown
@@ -1,0 +1,188 @@
+KES Agent Troubleshooting
+=========================
+
+This guide covers the situations operators most commonly hit when running the
+KES agent, how to tell a real problem from a harmless warning, and where to
+look. If you are setting up for the first time, also see the
+[Migration guide](migration.markdown) and the
+[Known-good-state checklist](guide.markdown#verifying-a-correct-setup-known-good-state).
+
+First stop: `kes-agent-control info`
+------------------------------------
+
+Most questions are answered by querying the agent:
+
+```sh
+kes-agent-control info        # or: KES_AGENT_CONTROL_PATH=... kes-agent-control info
+```
+
+The output is divided into labelled blocks:
+
+- **`--- Installed KES SignKey ---`** — the agent has an **active** key it is
+  serving to nodes. This block reports the `VerKey`, `Valid from period`,
+  `Current evolution: N / M`, and `OpCert number`. This is the block you want to
+  see.
+- **`--- Staged KES SignKey ---`** — a key has been generated but **not yet
+  activated**; it is waiting for a matching OpCert (`install-key`). A node will
+  not be served a staged key.
+- **`--- Bootstrap Peers ---`** — status of connections to other agents (see
+  below).
+
+If `info` itself fails to connect, the agent is not running or you are pointing
+at the wrong control socket — see *Socket and permission errors* below.
+
+Reading the logs
+----------------
+
+When the agent runs as a systemd service it logs to the journal:
+
+```sh
+# follow the agent service live:
+journalctl -u kes-agent -f
+
+# everything the agent logged since the last boot:
+journalctl -u kes-agent -b
+
+# narrow to a time window:
+journalctl -u kes-agent --since "10 min ago"
+```
+
+When run in the foreground (`kes-agent run ...`), it logs to stdout instead.
+
+For the node side, watch `cardano-node`'s own logs for the leadership-check and
+KES traces named in the
+[Known-good-state checklist](guide.markdown#verifying-a-correct-setup-known-good-state).
+
+Common situations
+-----------------
+
+### A bootstrap peer is stuck at `connecting...`
+
+In `--- Bootstrap Peers ---`, each peer shows one of three statuses: `up`
+(green), `connecting...` (yellow), or `down` (red). `connecting...` means the
+agent has this peer in its configuration and is trying to reach it but has not
+established a connection yet — and it will keep retrying indefinitely.
+
+**This is usually harmless.** Bootstrap peers are an *optional* redundancy
+mechanism for propagating a key between agents. If the agent already shows an
+**Installed KES SignKey** and your node is forging, a peer stuck at
+`connecting...` does **not** stop anything — it just means that particular peer
+is not reachable right now.
+
+The classic false alarm: you ran a foreground agent for testing, listed it as a
+bootstrap peer, then moved to a systemd agent. The foreground agent no longer
+exists, so it shows as permanently `connecting...`. Remove that address from the
+agent's bootstrap configuration to clear the noise.
+
+**When it *is* a problem:** if this agent has **no installed key** and is
+*relying* on a bootstrap peer to receive one (e.g. a backup agent after a
+reboot), then a peer that never leaves `connecting...` means the key is not
+arriving. Check that the peer agent is running and actually holds a key, and
+that the socket forwarding between them is up (see *SSH tunnel / multi-host*
+below).
+
+### The agent shows a Staged key but no Installed key
+
+A staged key is not served to nodes. You still need to issue an OpCert for it
+and install it:
+
+```sh
+kes-agent-control install-key --opcert-file opcert.cert
+```
+
+If `install-key` is rejected, the OpCert and the staged key do not match, or the
+OpCert serial number is not greater than the last one used — re-issue the OpCert
+from the air-gapped host's `opcert.counter` against the **current** staged
+verification key (`export-staged-vkey`). See the [Migration guide](migration.markdown).
+
+### The node is running but not producing blocks
+
+Not producing blocks has many possible causes beyond KES. Isolate the layer:
+
+- **KES** — does `kes-agent-control info` show an **Installed KES SignKey**, and
+  is the node started with `--shelley-kes-agent-socket`? Do the node's KES log
+  traces show the current KES period within the key's valid range?
+- **OpCert** — is the node using the **same** OpCert that matches the installed
+  key's verification key and serial number?
+- **VRF** — is `--shelley-vrf-key` present and correct? (Unchanged by KES agent
+  migration, but still required to forge.)
+- **Topology / connectivity** — is the block producer connected to relays and
+  fully synced (`cardano-cli query tip` → `syncProgress` `100.00`)?
+- **Stake / schedule** — with low stake you may simply have no slots assigned in
+  the current epoch. Confirm leadership checks are running before assuming a
+  fault.
+
+### Recovering after the agent restarted or the host rebooted
+
+The KES sign key lives only in memory, so an agent restart or full reboot drops
+it. What to do depends on your topology — this is covered in detail in
+[Restart & Recovery](guide.markdown#restart--recovery). In short: a
+**single-agent** setup needs the key re-installed (generate staged key → OpCert
+→ `install-key`); a **backup-agent** setup re-fetches the key from its peer
+automatically.
+
+### Confirming the node reconnected after a restart
+
+After restarting `cardano-node`, confirm it picked the key back up:
+
+1. `kes-agent-control info` still shows an Installed KES SignKey.
+2. The node logs show it connecting and KES traces appearing.
+3. Leadership checks resume.
+
+Run the full
+[Known-good-state checklist](guide.markdown#verifying-a-correct-setup-known-good-state)
+if in doubt.
+
+### Socket and permission errors
+
+If `kes-agent-control` cannot connect:
+
+- Confirm the agent is running (`systemctl status kes-agent`, or check your
+  foreground process).
+- Confirm you are pointing at the correct **control** socket — via
+  `-c <path>`, the `KES_AGENT_CONTROL_PATH` environment variable, or the default
+  `/tmp/kes-agent-control.socket`. Note the control socket and the **service**
+  socket (used by the node) are different sockets; do not mix them up.
+- Confirm the user running the command can access the socket file. Access is
+  governed by the socket's filesystem permissions — the user must be in the
+  `kes-agent` group (see [Installing KES Agent](guide.markdown#installing-kes-agent)).
+
+### "My change to the service file had no effect"
+
+After editing the systemd unit or environment file, systemd keeps running the
+old configuration until reloaded:
+
+```sh
+systemctl daemon-reload
+systemctl restart kes-agent      # note: this drops the in-memory key — see Restart & Recovery
+```
+
+Confirm the running process actually reflects your change:
+
+```sh
+systemctl show kes-agent -p ExecStart -p EnvironmentFiles
+ps -ef | grep kes-agent
+```
+
+Remember that **restarting the agent drops its in-memory key**; in a
+single-agent setup you must re-install a key afterwards.
+
+### SSH tunnel / multi-host issues
+
+When agents (or the node and agent) run on different hosts, they communicate
+over Unix domain sockets forwarded via SSH. If a connection that should be `up`
+is `connecting...`/`down`:
+
+- Confirm the `ssh`/`autossh` forwarding process is alive.
+- Confirm stale local socket files are cleaned up — use
+  `-o StreamLocalBindUnlink=yes` (see
+  [Running on separate hosts](guide.markdown#running-cardano-node-kes-agent-control-andor-kes-agent-on-separate-hosts)).
+- Confirm the forwarding maps the correct **service** sockets on both ends.
+
+See also
+--------
+
+- [Migration guide](migration.markdown)
+- [Restart & Recovery](guide.markdown#restart--recovery)
+- [Known-good-state checklist](guide.markdown#verifying-a-correct-setup-known-good-state)
+- [FAQ](faq.markdown)


### PR DESCRIPTION
Add operator-facing docs flagged as high-impact in the May 2026 SPO feedback form.

  - guide: add Glossary, "Restart & Recovery" matrix, and a known-good-state checklist; replace the "undocumented" C-library steps with libsodium (IOG fork) / secp256k1 / libblst commands mirroring the cardano-node dev portal.
  - migration.markdown (new): ordered migration from on-disk KES key to the agent, incl. the foreground-to-systemd move.
  - troubleshooting.markdown (new): journalctl filters, info-output guide, and symptom/fix entries (e.g. benign bootstrap "connecting...").
  - faq: add the missing "agent restarts" case.
  - README: link the four docs.
  - doc/README.md (new): documentation index routing to the four docs.
  
 